### PR TITLE
(#9) Save page, returning a GUID.

### DIFF
--- a/src/CancerGov.CTS.Print/DataManager/PrintCacheManager.cs
+++ b/src/CancerGov.CTS.Print/DataManager/PrintCacheManager.cs
@@ -1,20 +1,13 @@
-﻿using System.Web;
-using System;
-using System.Collections;
-//using System.Web.Script.Serialization;
+﻿using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.Data;
 using System.Data.SqlClient;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
-//using NCI.Util;
 using NCI.Data;
 using NCI.DataManager;
 using Common.Logging;
-//using CancerGov.Common.ErrorHandling;
-using NCI.Web.CDE.Application;
 
 using CancerGov.CTS.Print.Models;
 
@@ -48,37 +41,38 @@ namespace CancerGov.CTS.Print.DataManager
         //public static Guid SavePrintResult(string content, IEnumerable<String> trialIDs, CTSSearchParams searchParams, bool isLive)
         public Guid Save(string[] trialIds, SearchCriteria searchParams, string content)
         {
-            throw new NotImplementedException();
-            //DataTable dt = new DataTable();
-            //using (SqlConnection conn = new SqlConnection(ConfigurationManager.ConnectionStrings["DbConnectionString"].ConnectionString))
-            //{
-            //    Guid printResultGuid = Guid.Empty;
+            DataTable dt = new DataTable();
+            using (SqlConnection conn = new SqlConnection(ConfigurationManager.ConnectionStrings["DbConnectionString"].ConnectionString))
+            {
+                Guid printResultGuid = Guid.Empty;
 
-            //    SqlParameter[] parameters = {
-            //        new SqlParameter("@printid", SqlDbType.UniqueIdentifier),
-            //        new SqlParameter("@content", SqlDbType.NVarChar, content.Length),
-            //        new SqlParameter("@searchparams", SqlDbType.NVarChar),
-            //        new SqlParameter("@isLive", SqlDbType.Bit),
-            //        new SqlParameter("@trialids", SqlDbType.Structured)
-            //    };
-            //    parameters[0].Direction = ParameterDirection.Output;
-            //    parameters[1].Value = content;
-            //    parameters[2].Value = new JavaScriptSerializer().Serialize(searchParams);
-            //    parameters[3].Value = 1; // Legacy argument. The "preview" site is no longer used.
-            //    parameters[4].Value = CreatePrintIdDataTable(trialIds);
+                // Do something here to turn searchParams into a string.  Maybe a really nifty ToString() implementation.....
 
-            //    try
-            //    {
-            //        SqlHelper.ExecuteNonQuery(conn, CommandType.StoredProcedure, "dbo.ct_insertPrintresultcache", parameters);
-            //        printResultGuid = (Guid)parameters[0].Value;
-            //    }
-            //    catch (SqlException ex)
-            //    {
-            //        log.Error("Unable to save data. Search Params: " + searchParams + "isLive: " + isLive, 2, ex);
-            //    }
+                SqlParameter[] parameters = {
+                    new SqlParameter("@printid", SqlDbType.UniqueIdentifier),
+                    new SqlParameter("@content", SqlDbType.NVarChar, content.Length),
+                    new SqlParameter("@searchparams", SqlDbType.NVarChar),
+                    new SqlParameter("@isLive", SqlDbType.Bit),
+                    new SqlParameter("@trialids", SqlDbType.Structured)
+                };
+                parameters[0].Direction = ParameterDirection.Output;
+                parameters[1].Value = content;
+                parameters[2].Value = searchParams.ToJson();
+                parameters[3].Value = 1; // Legacy argument. The "preview" site is no longer used.
+                parameters[4].Value = CreatePrintIdDataTable(trialIds);
 
-            //    return printResultGuid;
-            //}
+                try
+                {
+                    SqlHelper.ExecuteNonQuery(conn, CommandType.StoredProcedure, "dbo.ct_insertPrintresultcache", parameters);
+                    printResultGuid = (Guid)parameters[0].Value;
+                }
+                catch (SqlException ex)
+                {
+                    log.Error("Unable to save data. Search Params: " + searchParams, ex);
+                }
+
+                return printResultGuid;
+            }
         }
 
         private static DataTable CreatePrintIdDataTable(IEnumerable<String> trialIDs)

--- a/src/CancerGov.CTS.Print/Models/SearchCriteria.cs
+++ b/src/CancerGov.CTS.Print/Models/SearchCriteria.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
+using Newtonsoft.Json;
 
 namespace CancerGov.CTS.Print.Models
 {
@@ -60,6 +59,15 @@ namespace CancerGov.CTS.Print.Models
         public void Add(string label, string value)
         {
             criteriaList.Add (new Criterion (label, value));
+        }
+
+        /// <summary>
+        /// Creates the JSON representation of the criteria list.
+        /// </summary>
+        /// <returns>A JSON array containing the list of criteria.</returns>
+        public string ToJson()
+        {
+            return JsonConvert.SerializeObject(criteriaList);
         }
     }
 }

--- a/test/CancerGov.CTS.Print.Test/CancerGov.CTS.Print.Test.csproj
+++ b/test/CancerGov.CTS.Print.Test/CancerGov.CTS.Print.Test.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Tests\Models\SearchCriteria_CriteriaList.cs" />
     <Compile Include="Tests\Models\SearchCriteria_HasCriteria.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Tests\Models\SearchCriteria_ToJson.cs" />
     <Compile Include="Tests\Rendering\PrintRenderer_Instantiation.cs" />
     <Compile Include="Tests\Rendering\PrintRenderer_Render.cs" />
   </ItemGroup>

--- a/test/CancerGov.CTS.Print.Test/Tests/Models/SearchCriteria_ToJson.cs
+++ b/test/CancerGov.CTS.Print.Test/Tests/Models/SearchCriteria_ToJson.cs
@@ -1,0 +1,59 @@
+﻿
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+using CancerGov.CTS.Print.Models;
+
+namespace CancerGov.CTS.Print.Test.Tests.Models
+{
+    public class SearchCriteria_ToJson
+    {
+        [Fact]
+        public void EmptyList()
+        {
+            JToken expected = JToken.Parse("[]");
+
+            var criteria = new SearchCriteria();
+            string json = criteria.ToJson();
+            JToken actual = JToken.Parse(json);
+
+            Assert.Equal(expected, actual, new JTokenEqualityComparer());
+        }
+
+        [Fact]
+        public void SingleListEntry()
+        {
+            JToken expected = JToken.Parse(@"
+            [
+                {""Label"":""Label 1"",""Value"":""Value 1""}
+            ]");
+
+            var criteria = new SearchCriteria();
+            criteria.Add("Label 1", "Value 1");
+            string json = criteria.ToJson();
+            JToken actual = JToken.Parse(json);
+
+            Assert.Equal(expected, actual, new JTokenEqualityComparer());
+        }
+
+        [Fact]
+        public void MultipleListEntries()
+        {
+            JToken expected = JToken.Parse(@"
+            [
+                {""Label"":""Label 1"",""Value"":""Value 1""},
+                {""Label"":""Label 2"",""Value"":""Value 2""},
+                {""Label"":""Label 3"",""Value"":""Value 3""}
+            ]");
+
+            var criteria = new SearchCriteria();
+            criteria.Add("Label 1", "Value 1");
+            criteria.Add("Label 2", "Value 2");
+            criteria.Add("Label 3", "Value 3");
+            string json = criteria.ToJson();
+            JToken actual = JToken.Parse(json);
+
+            Assert.Equal(expected, actual, new JTokenEqualityComparer());
+        }
+    }
+}

--- a/test/CancerGov.CTS.Print.Test/Tests/Rendering/PrintRenderer_Render.cs
+++ b/test/CancerGov.CTS.Print.Test/Tests/Rendering/PrintRenderer_Render.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 using Newtonsoft.Json.Linq;
 using Xunit;


### PR DESCRIPTION
- Save search criteria and trial IDs.
- Serialize SearchCriteria objects to JSON string.

Close #9 