### PR TITLE
(#27) Use explicit content type for cached page.

### DIFF
--- a/src/NCI.OCPL.ClinicalTrialSearchPrint/CTSPrintRequestHandler.cs
+++ b/src/NCI.OCPL.ClinicalTrialSearchPrint/CTSPrintRequestHandler.cs
@@ -74,6 +74,7 @@ namespace NCI.OCPL.ClinicalTrialSearchPrint
                 (int StatusCode, string Content) result = await GetCachedContent(request.QueryString["printid"]);
 
                 context.Response.StatusCode = result.StatusCode;
+                context.Response.ContentType = "text/html";
                 context.Response.Write(result.Content);
             }
             // Anything else, return an error.


### PR DESCRIPTION
Looked at setting a different content type for error returns, but IIS
overrides that with text/html.

Closes #27 
