### PR TITLE
(#66) Fix cross site scripting vulnerability.

### DIFF
--- a/integration-test/features/generate-errors.feature
+++ b/integration-test/features/generate-errors.feature
@@ -31,7 +31,7 @@ Scenario: Status 400 when trial_ids is missing from the request body.
     """
     When method post
     Then status 400
-    And match reponse == 'trial_ids list is required.'
+    And match response == "Field 'trial_ids' not found."
 
 Scenario Outline: Status 400 when trial_ids is present but null or empty.
 
@@ -46,10 +46,54 @@ Scenario Outline: Status 400 when trial_ids is present but null or empty.
     """
     When method post
     Then status 400
-    And match reponse == 'trial_ids list is required.'
+    And match response == "Field 'trial_ids' not found."
 
     Examples:
     | trial_list |
     | []         |
     | null       |
+
+Scenario Outline: Status 400 when the new_search_link field contains invalid characters (e.g. an injection attack)
+
+    Given path 'CTS.Print', 'GenCache'
+    And request
+    """
+    {
+        "trial_ids": [ "NCI-2018-03694", "NCI-2020-00544", "NCI-2018-01575" ],
+        "link_template": "/about-cancer/treatment/clinical-trials/search/v?t=C3208&st=C3471&a=24&loc=1&z=20850&zp=100&rl=2&id=<TRIAL_ID>",
+        "search_criteria": null,
+        "new_search_link": search_link
+    }
+    """
+    When method post
+    Then status 400
+    And match response == "Field 'new_search_link' has an invalid value."
+
+    Examples:
+    | search_link |
+    | "/about-cancer/treatment/clinical-trials/search/advanced\\\" onClick=\\\"alert('Oops!')\\\"" |
+    | "/about-cancer/treatment/clinical-trials/search/advanced\\\" ></a> <p>evil markdown</p>"     |
+
+
+Scenario Outline: Status 400 when the link_template field contains invalid characters (e.g. an injection attack)
+
+    Given path 'CTS.Print', 'GenCache'
+    And request
+    """
+    {
+        "trial_ids": [ "NCI-2018-03694", "NCI-2020-00544", "NCI-2018-01575" ],
+        "new_search_link": "/about-cancer/treatment/clinical-trials/search/advanced",
+        "search_criteria": null,
+        "link_template": template
+    }
+    """
+    When method post
+    Then status 400
+    And match response == "Field 'link_template' has an invalid value."
+
+    Examples:
+    | template |
+    | "/about-cancer/treatment/clinical-trials/search/v?t=C3208&st=C3471&a=24&loc=1&z=20850&zp=100&rl=2&id=<TRIAL_ID>\\\" onClick=\\\"alert('Oops!')\\\"" |
+    | "/about-cancer/treatment/clinical-trials/search/v?t=C3208&st=C3471&a=24&loc=1&z=20850&zp=100&rl=2&id=<TRIAL_ID>\\\" ></a> <p>evil markdown</p>"     |
+
 

--- a/test/NCI.OCPL.ClinicalTrialSearchPrint.Test/NCI.OCPL.ClinicalTrialSearchPrint.Test.csproj
+++ b/test/NCI.OCPL.ClinicalTrialSearchPrint.Test/NCI.OCPL.ClinicalTrialSearchPrint.Test.csproj
@@ -77,10 +77,14 @@
     <Compile Include="TestObjects\CTSPrintRequestHandler_GetFields_LinkTemplate_Null.cs" />
     <Compile Include="TestObjects\CTSPrintRequestHandler_GetFields_LinkTemplate_RelativePath.cs" />
     <Compile Include="TestObjects\CTSPrintRequestHandler_GetFields_LinkTemplate_AbsoluteUrl.cs" />
+    <Compile Include="TestObjects\CTSPrintRequestHandler_GetFields_LinkTemplate_InjectAttribute.cs" />
+    <Compile Include="TestObjects\CTSPrintRequestHandler_GetFields_LinkTemplate_InjectMarkup.cs" />
+    <Compile Include="TestObjects\CTSPrintRequestHandler_GetFields_NewSearchLink_InjectMarkup.cs" />
     <Compile Include="TestObjects\CTSPrintRequestHandler_GetFields_NewSearchLink_Null.cs" />
     <Compile Include="TestObjects\CTSPrintRequestHandler_GetFields_NewSearchLink_Empty.cs" />
     <Compile Include="TestObjects\CTSPrintRequestHandler_GetFields_NewSearchLink_Missing.cs" />
     <Compile Include="TestObjects\CTSPrintRequestHandler_GetFields_NewSearchLink_AbsoluteUrl.cs" />
+    <Compile Include="TestObjects\CTSPrintRequestHandler_GetFields_NewSearchLink_InjectAttribute.cs" />
     <Compile Include="TestObjects\CTSPrintRequestHandler_GetFields_NewSearchLink_RelativePath.cs" />
     <Compile Include="TestObjects\CTSPrintRequestHandler_GetFields_NewSearchLink_Present.cs" />
     <Compile Include="TestObjects\CTSPrintRequestHandler_GetFields_SearchCriteria_Missing.cs" />

--- a/test/NCI.OCPL.ClinicalTrialSearchPrint.Test/TestObjects/CTSPrintRequestHandler_GetFields_Base.cs
+++ b/test/NCI.OCPL.ClinicalTrialSearchPrint.Test/TestObjects/CTSPrintRequestHandler_GetFields_Base.cs
@@ -8,13 +8,31 @@ namespace NCI.OCPL.ClinicalTrialSearchPrint.Test
         public abstract JObject RequestData { get; }
 
         // The Expected.... fields don't need to be overridden unless a test
-        // case uses that particular value. Rather than 
+        // case uses that particular value.
+
+        /// <summary>
+        /// The list of trials which is expected be returned.
+        /// </summary>
         public virtual string[] ExpectedTrials => new string[] { "This is the default value." };
 
+        /// <summary>
+        /// The link template which is expected to be returned.
+        /// </summary>
         public virtual string ExpectedLinkTemplate => "This is the defaualt value.";
 
+        /// <summary>
+        /// The new search link which is expected to be returned.
+        /// </summary>
         public virtual string ExpectedNewSearchLink => "This is the default value.";
 
+        /// <summary>
+        /// The search criteria which are expected be returned.
+        /// </summary>
         public virtual JObject ExpectedSearchCriteria => JObject.Parse("{\"default-key\": \"This is the default value.\"}");
+
+        /// <summary>
+        /// The name of a field which is expected to cause a problem.
+        /// </summary>
+        public virtual string ExpectedErrorFieldName => "This is the default value.";
     }
 }

--- a/test/NCI.OCPL.ClinicalTrialSearchPrint.Test/TestObjects/CTSPrintRequestHandler_GetFields_LinkTemplate_InjectAttribute.cs
+++ b/test/NCI.OCPL.ClinicalTrialSearchPrint.Test/TestObjects/CTSPrintRequestHandler_GetFields_LinkTemplate_InjectAttribute.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json.Linq;
+
+namespace NCI.OCPL.ClinicalTrialSearchPrint.Test
+{
+    // Attempt to inject an attribute into the new_search_link field.
+    class CTSPrintRequestHandler_GetFields_LinkTemplate_InjectAttribute
+        : CTSPrintRequestHandler_GetFields_Base
+    {
+        public override JObject RequestData =>
+            JObject.Parse(@"
+{
+    ""trial_ids"": [""NCI-2015-01906""],
+    ""link_template"": ""/about-cancer/treatment/clinical-trials/search/v?t=C3208&st=C3471&a=24&loc=1&z=20850&zp=100&rl=2&id=<TRIAL_ID>\"" onClick=\""alert('Oops!')\"""",
+    ""new_search_link"": ""/about-cancer/treatment/clinical-trials/search/advanced"",
+    ""search_criteria"": null
+}
+");
+
+        public override string ExpectedErrorFieldName => "link_template";
+    }
+}

--- a/test/NCI.OCPL.ClinicalTrialSearchPrint.Test/TestObjects/CTSPrintRequestHandler_GetFields_LinkTemplate_InjectMarkup.cs
+++ b/test/NCI.OCPL.ClinicalTrialSearchPrint.Test/TestObjects/CTSPrintRequestHandler_GetFields_LinkTemplate_InjectMarkup.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json.Linq;
+
+namespace NCI.OCPL.ClinicalTrialSearchPrint.Test
+{
+    // Attempt to inject markup into the new_search_link field.
+    class CTSPrintRequestHandler_GetFields_LinkTemplate_InjectMarkup
+        : CTSPrintRequestHandler_GetFields_Base
+    {
+        public override JObject RequestData =>
+            JObject.Parse(@"
+{
+    ""trial_ids"": [""NCI-2015-01906""],
+    ""link_template"": ""/about-cancer/treatment/clinical-trials/search/v?t=C3208&st=C3471&a=24&loc=1&z=20850&zp=100&rl=2&id=<TRIAL_ID>\""> </a> <p>Evil markup</p>"",
+    ""new_search_link"": ""/about-cancer/treatment/clinical-trials/search/advanced"",
+    ""search_criteria"": null
+}
+");
+
+        public override string ExpectedErrorFieldName => "link_template";
+    }
+}

--- a/test/NCI.OCPL.ClinicalTrialSearchPrint.Test/TestObjects/CTSPrintRequestHandler_GetFields_NewSearchLink_InjectAttribute.cs
+++ b/test/NCI.OCPL.ClinicalTrialSearchPrint.Test/TestObjects/CTSPrintRequestHandler_GetFields_NewSearchLink_InjectAttribute.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json.Linq;
+
+namespace NCI.OCPL.ClinicalTrialSearchPrint.Test
+{
+    // Attempt to inject an attribute into the new_search_link field.
+    class CTSPrintRequestHandler_GetFields_NewSearchLink_InjectAttribute
+        : CTSPrintRequestHandler_GetFields_Base
+    {
+        public override JObject RequestData =>
+            JObject.Parse(@"
+{
+    ""trial_ids"": [""NCI-2015-01906""],
+    ""link_template"": ""/about-cancer/treatment/clinical-trials/search/v?t=C3208&st=C3471&a=24&loc=1&z=20850&zp=100&rl=2&id=<TRIAL_ID>"",
+    ""new_search_link"": ""/about-cancer/treatment/clinical-trials/search/advanced\"" onClick=\""alert('Oops!')\"""",
+    ""search_criteria"": null
+}
+");
+
+        public override string ExpectedErrorFieldName => "new_search_link";
+    }
+}

--- a/test/NCI.OCPL.ClinicalTrialSearchPrint.Test/TestObjects/CTSPrintRequestHandler_GetFields_NewSearchLink_InjectMarkup.cs
+++ b/test/NCI.OCPL.ClinicalTrialSearchPrint.Test/TestObjects/CTSPrintRequestHandler_GetFields_NewSearchLink_InjectMarkup.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json.Linq;
+
+namespace NCI.OCPL.ClinicalTrialSearchPrint.Test
+{
+    // Attempt to inject markup into the new_search_link field.
+    class CTSPrintRequestHandler_GetFields_NewSearchLink_InjectMarkup
+        : CTSPrintRequestHandler_GetFields_Base
+    {
+        public override JObject RequestData =>
+            JObject.Parse(@"
+{
+    ""trial_ids"": [""NCI-2015-01906""],
+    ""link_template"": ""/about-cancer/treatment/clinical-trials/search/v?t=C3208&st=C3471&a=24&loc=1&z=20850&zp=100&rl=2&id=<TRIAL_ID>"",
+    ""new_search_link"": ""/about-cancer/treatment/clinical-trials/search/advanced\""> </a> <p>Evil markup</p>"",
+    ""search_criteria"": null
+}
+");
+
+        public override string ExpectedErrorFieldName => "new_search_link";
+    }
+}

--- a/test/NCI.OCPL.ClinicalTrialSearchPrint.Test/Tests/CTSPrintRequestHandler_GetFields.cs
+++ b/test/NCI.OCPL.ClinicalTrialSearchPrint.Test/Tests/CTSPrintRequestHandler_GetFields.cs
@@ -228,5 +228,31 @@ namespace NCI.OCPL.ClinicalTrialSearchPrint.Test
 
             Assert.Equal(data.ExpectedSearchCriteria, actual.SearchCriteria, new JTokenEqualityComparer());
         }
+
+        public static IEnumerable<object[]> FieldsWithDisallowedCharacters_Data = new[]
+        {
+            new object[] {new CTSPrintRequestHandler_GetFields_NewSearchLink_InjectAttribute()},
+            new object[] {new CTSPrintRequestHandler_GetFields_NewSearchLink_InjectMarkup()},
+            new object[] {new CTSPrintRequestHandler_GetFields_LinkTemplate_InjectAttribute()},
+            new object[] {new CTSPrintRequestHandler_GetFields_LinkTemplate_InjectMarkup()},
+        };
+
+        /// <summary>
+        /// Tests for fields containing disallowed characters. (e.g. Injection attacks.)
+        /// </summary>
+        /// <param name="data"></param>
+        [Theory]
+        [MemberData(nameof(FieldsWithDisallowedCharacters_Data))]
+        public static void FieldsWithDisallowedCharacters(CTSPrintRequestHandler_GetFields_Base data)
+        {
+            var handler = new CTSPrintRequestHandler();
+
+            ArgumentException ex = Assert.Throws<ArgumentException>(
+                () => handler.GetFields(data.RequestData)
+            );
+
+            Assert.Equal(data.ExpectedErrorFieldName, ex.ParamName);
+            Assert.StartsWith(CTSPrintRequestHandler.INVALID_CHARACTERS_MESSAGE, ex.Message);
+        }
     }
 }


### PR DESCRIPTION
- Block characters that shouldn't appear in new_search_link and
  link_template fields.
- Add matching unit and integration tests.
- Incidental fix for missing field message in test.

Closes #66 
