### PR TITLE
(#68) Allow underscores in the link template.

### DIFF
--- a/src/NCI.OCPL.ClinicalTrialSearchPrint/CTSPrintRequestHandler.cs
+++ b/src/NCI.OCPL.ClinicalTrialSearchPrint/CTSPrintRequestHandler.cs
@@ -252,7 +252,7 @@ namespace NCI.OCPL.ClinicalTrialSearchPrint
 
             // Finder for characters not allowed in the link_template field.
             // This is broader in order to allow URL encoded characters.
-            Regex linkTemplateDisallowedCharacters = new Regex("[^a-zA-Z0-9-/.&=?%]");
+            Regex linkTemplateDisallowedCharacters = new Regex("[^a-zA-Z0-9-/.&=?%_]+");
 
             string[] trialIDs;
             string linkTemplate;

--- a/test/NCI.OCPL.ClinicalTrialSearchPrint.Test/NCI.OCPL.ClinicalTrialSearchPrint.Test.csproj
+++ b/test/NCI.OCPL.ClinicalTrialSearchPrint.Test/NCI.OCPL.ClinicalTrialSearchPrint.Test.csproj
@@ -75,6 +75,7 @@
   <ItemGroup>
     <Compile Include="TestObjects\CTSPrintRequestHandler_GetFields_Base.cs" />
     <Compile Include="TestObjects\CTSPrintRequestHandler_GetFields_LinkTemplate_Null.cs" />
+    <Compile Include="TestObjects\CTSPrintRequestHandler_GetFields_LinkTemplate_AllowUnderscores.cs" />
     <Compile Include="TestObjects\CTSPrintRequestHandler_GetFields_LinkTemplate_RelativePath.cs" />
     <Compile Include="TestObjects\CTSPrintRequestHandler_GetFields_LinkTemplate_AbsoluteUrl.cs" />
     <Compile Include="TestObjects\CTSPrintRequestHandler_GetFields_LinkTemplate_InjectAttribute.cs" />

--- a/test/NCI.OCPL.ClinicalTrialSearchPrint.Test/TestObjects/CTSPrintRequestHandler_GetFields_LinkTemplate_AllowUnderscores.cs
+++ b/test/NCI.OCPL.ClinicalTrialSearchPrint.Test/TestObjects/CTSPrintRequestHandler_GetFields_LinkTemplate_AllowUnderscores.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json.Linq;
+
+namespace NCI.OCPL.ClinicalTrialSearchPrint.Test
+{
+    /// <summary>
+    /// Test data for allowing underscores in the link template (e.g. trial type = "basic_science").
+    /// </summary>
+    class CTSPrintRequestHandler_GetFields_LinkTemplate_AllowUnderscores
+        : CTSPrintRequestHandler_GetFields_Base
+    {
+        public override JObject RequestData =>
+            JObject.Parse(@"
+{
+    ""trial_ids"": [""NCI-2015-01906""],
+    ""link_template"": ""/about-cancer/treatment/clinical-trials/search/v?loc=0&rl=2&tt=basic_science&id=<TRIAL_ID>"",
+    ""new_search_link"": ""/about-cancer/treatment/clinical-trials/search/advanced"",
+    ""search_criteria"": null
+}
+");
+
+        public override string[] ExpectedTrials => new string[] { "NCI-2021-08584" };
+
+        public override string ExpectedLinkTemplate => "/about-cancer/treatment/clinical-trials/search/v?loc=0&rl=2&tt=basic_science&id=<TRIAL_ID>";
+    }
+}

--- a/test/NCI.OCPL.ClinicalTrialSearchPrint.Test/Tests/CTSPrintRequestHandler_GetFields.cs
+++ b/test/NCI.OCPL.ClinicalTrialSearchPrint.Test/Tests/CTSPrintRequestHandler_GetFields.cs
@@ -106,7 +106,8 @@ namespace NCI.OCPL.ClinicalTrialSearchPrint.Test
 
         public static IEnumerable<object[]> LinkTemplatePresent_Data = new[]
         {
-            new object[] {new CTSPrintRequestHandler_GetFields_LinkTemplate_Present() }
+            new object[] {new CTSPrintRequestHandler_GetFields_LinkTemplate_Present() },
+            new object[] {new CTSPrintRequestHandler_GetFields_LinkTemplate_AllowUnderscores() },
         };
 
         /// <summary>


### PR DESCRIPTION
Closes #68 
