### PR TITLE
(#79) Break multiple trial lookups into chunks.

### DIFF
--- a/src/CancerGov.ClinicalTrialsAPI/IClinicalTrialsAPIClient.cs
+++ b/src/CancerGov.ClinicalTrialsAPI/IClinicalTrialsAPIClient.cs
@@ -20,10 +20,9 @@ namespace CancerGov.ClinicalTrialsAPI
         /// Retrieve the details of a list of trials.
         /// </summary>
         /// <param name="trialIDs">The set of trials to retrieve</param>
-        /// <param name="from">Offset into the set of possible returns for the first result to retrieve.</param>
         /// <param name="size">Number of results to retrieve.</param>
         /// <returns>An object containing an array of trial details.</returns>
-        Task<JObject> GetMultipleTrials(IEnumerable<string> trialIDs, int size = 10, int from = 0);
+        Task<JObject> GetMultipleTrials(IEnumerable<string> trialIDs);
 
         /// <summary>
         /// Gets a collection of disease names from the API.

--- a/src/NCI.OCPL.ClinicalTrialSearchPrint/CTSPrintRequestHandler.cs
+++ b/src/NCI.OCPL.ClinicalTrialSearchPrint/CTSPrintRequestHandler.cs
@@ -194,7 +194,7 @@ namespace NCI.OCPL.ClinicalTrialSearchPrint
             try
             {
                 IClinicalTrialsAPIClient apiClient = GetClinicalTrialsApiClient();
-                trialDetails = await apiClient.GetMultipleTrials(trialIDs, trialIDs.Length);
+                trialDetails = await apiClient.GetMultipleTrials(trialIDs);
             }
             catch (Exception ex)
             {

--- a/test/CancerGov.ClinicalTrialsAPI.Test/CancerGov.ClinicalTrialsAPI.Test.csproj
+++ b/test/CancerGov.ClinicalTrialsAPI.Test/CancerGov.ClinicalTrialsAPI.Test.csproj
@@ -84,6 +84,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ClinicalTrialsAPIClientTests_Chunks.cs" />
     <Compile Include="ClinicalTrialsAPIClientTests_General.cs" />
     <Compile Include="ClinicalTrialsAPIClientTests_GetMultipleTrials.cs" />
     <Compile Include="ClinicalTrialsAPIClientTests_GetOneTrial.cs" />

--- a/test/CancerGov.ClinicalTrialsAPI.Test/ClinicalTrialsAPIClientTests_Chunks.cs
+++ b/test/CancerGov.ClinicalTrialsAPI.Test/ClinicalTrialsAPIClientTests_Chunks.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+using Moq;
+using RichardSzalay.MockHttp;
+using Xunit;
+
+namespace CancerGov.ClinicalTrialsAPI.Test
+{
+    /// <summary>
+    /// Tests for the ClinicalTrialsAPIClient.Chunks method.
+    /// </summary>
+    public class ClinicalTrialsAPIClientTests_Chunks
+    {
+        /// <summary>
+        /// Verify chunking works correctly when chunk size is larger than the list's.
+        /// </summary>
+        [Fact]
+        public void ChunkIsLargerThanListSize()
+        {
+            const int CHUNK_SIZE = 10;
+
+            string[] input = new[] { "one", "two", "three" };
+            string[] expected = new[] { "one", "two", "three" };
+
+            IEnumerable<IEnumerable<string>> actual = ClinicalTrialsAPIClient.Chunks(input, CHUNK_SIZE);
+
+            IEnumerable<string>[] actualAsArray = actual.ToArray();
+
+            Assert.Single(actual);
+            Assert.Equal(expected, actual.First());
+        }
+
+        /// <summary>
+        /// Verify chunking works correctly when the chunk size is smaller than the list's.
+        /// </summary>
+        [Fact]
+        public void ChunkIsSmallerThanListSize()
+        {
+            const int CHUNK_SIZE = 3;
+
+            string[] input = new[] { "one", "two", "three", "four" };
+            string[] expected1 = new[] { "one", "two", "three" };
+            string[] expected2 = new[] { "four" };
+
+
+            IEnumerable<IEnumerable<string>> actual = ClinicalTrialsAPIClient.Chunks(input, CHUNK_SIZE);
+
+            IEnumerator<IEnumerable<string>> enumerator = actual.GetEnumerator();
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(expected1, enumerator.Current);
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(expected2, enumerator.Current);
+
+            Assert.False(enumerator.MoveNext());
+        }
+
+        /// <summary>
+        /// Verify chunking works correctly when the list's size is exactly divisible
+        /// by the chunk size.
+        /// </summary>
+        [Fact]
+        public void ChunkIsExactPortionOfListSize()
+        {
+            const int CHUNK_SIZE = 2;
+
+            string[] input = new[] { "one", "two", "three", "four", "five", "six" };
+            string[] expected1 = new[] { "one", "two" };
+            string[] expected2 = new[] { "three", "four" };
+            string[] expected3 = new[] { "five", "six" };
+
+
+            IEnumerable<IEnumerable<string>> actual = ClinicalTrialsAPIClient.Chunks(input, CHUNK_SIZE);
+
+            IEnumerator<IEnumerable<string>> enumerator = actual.GetEnumerator();
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(expected1, enumerator.Current);
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(expected2, enumerator.Current);
+
+            Assert.True(enumerator.MoveNext());
+            Assert.Equal(expected3, enumerator.Current);
+
+            Assert.False(enumerator.MoveNext());
+        }
+
+    }
+}


### PR DESCRIPTION
Fixes #79 
