### PR TITLE
(#122) Remove dependency on VS2022.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -30,9 +30,6 @@ jobs:
 
     - name: Setup MSBuild Path
       uses: microsoft/setup-msbuild@v2
-      with:
-        # Stick to VS 2022, block later versions for now.
-        vs-version: '[17.0,18.0)'
 
     - name: Setup NuGet
       uses: NuGet/setup-nuget@v2

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -20,7 +20,7 @@ jobs:
   test_build_release:
 
     name: Test, Build, and Publish
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     permissions:
       contents: read
 


### PR DESCRIPTION
Allow build to use the latest version of the Visual Studio tooling

Touches #122 